### PR TITLE
Fully remove 1.9.3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
-#Change Log
+# Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-## [1.0.0] - 2017-07-6
+### Breaking Changes
+- Minimum Ruby runtime version is now 2.0
+
+## [1.0.0] - 2017-07-06
 ### Breaking Changes
 - Removed Ruby 1.9 support
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 ## Sensu-Plugins-flowdock
 
-[ ![Build Status](https://travis-ci.org/sensu-plugins/sensu-plugins-flowdock.svg?branch=master)](https://travis-ci.org/sensu-plugins/sensu-plugins-flowdock)
+[![Build Status](https://travis-ci.org/sensu-plugins/sensu-plugins-flowdock.svg?branch=master)](https://travis-ci.org/sensu-plugins/sensu-plugins-flowdock)
 [![Gem Version](https://badge.fury.io/rb/sensu-plugins-flowdock.svg)](http://badge.fury.io/rb/sensu-plugins-flowdock)
-[![Code Climate](https://codeclimate.com/github/sensu-plugins/sensu-plugins-flowdock/badges/gpa.svg)](https://codeclimate.com/github/sensu-plugins/sensu-plugins-flowdock)
-[![Test Coverage](https://codeclimate.com/github/sensu-plugins/sensu-plugins-flowdock/badges/coverage.svg)](https://codeclimate.com/github/sensu-plugins/sensu-plugins-flowdock)
 [![Dependency Status](https://gemnasium.com/sensu-plugins/sensu-plugins-flowdock.svg)](https://gemnasium.com/sensu-plugins/sensu-plugins-flowdock)
-"!https://codeship.com/projects/69409d80-ea31-0132-13b2-32dfa18a9fce/status?branch=master!":https://codeship.com/projects/83073
 
 ## Functionality
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,15 +6,6 @@ require 'rubocop/rake_task'
 require 'yard'
 require 'yard/rake/yardoc_task'
 
-desc 'Don\'t run Rubocop for unsupported versions'
-begin
-  args = if RUBY_VERSION >= '2.0.0'
-           [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
-         else
-           [:spec, :make_bin_executable, :yard]
-         end
-end
-
 YARD::Rake::YardocTask.new do |t|
   OTHER_PATHS = %w().freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
@@ -44,4 +35,4 @@ task :check_binstubs do
   end
 end
 
-task default: args
+task default: [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]

--- a/sensu-plugins-flowdock.gemspec
+++ b/sensu-plugins-flowdock.gemspec
@@ -2,18 +2,10 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
-
-if RUBY_VERSION < '2.0.0'
-  require 'sensu-plugins-flowdock'
-else
-  require_relative 'lib/sensu-plugins-flowdock'
-end
-
-# pvt_key = '~/.ssh/gem-private_key.pem'
+require_relative 'lib/sensu-plugins-flowdock'
 
 Gem::Specification.new do |s|
   s.authors                = ['Sensu-Plugins and contributors']
-  # s.cert_chain             = ['certs/sensu-plugins.pem']
   s.date                   = Date.today.to_s
   s.description            = 'Sensu flowdock plugins'
   s.email                  = '<sensu-users@googlegroups.com>'
@@ -30,8 +22,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 1.9.3'
-  # s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME =~ /gem\z/
+  s.required_ruby_version  = '>= 2.0.0'
   s.summary                = 'Sensu plugins for flowdock'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsFlowdock::Version::VER_STRING


### PR DESCRIPTION
## Pull Request Checklist

Followup to #7. Technically this is a breaking change since the previous release still worked on 1.9.3.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Existing tests pass 

#### Purpose

Drop 1.9.3 support. Also some misc cleanup.

#### Known Compatablity Issues

Minimum Ruby version is now 2.0